### PR TITLE
Updating CodeceptionAdapter.php 'run' command

### DIFF
--- a/src/CodeceptionAdapter.php
+++ b/src/CodeceptionAdapter.php
@@ -57,7 +57,6 @@ final class CodeceptionAdapter implements MemoryUsageAware, TestFrameworkAdapter
     public const NAME = 'codeception';
 
     private const DEFAULT_ARGS_AND_OPTIONS = [
-        'run',
         '--no-colors',
         '--fail-fast',
     ];
@@ -335,6 +334,7 @@ AUTOLOAD;
     private function prepareArgumentsAndOptions(string $extraOptions): array
     {
         return array_filter(array_merge(
+            ['run'],
             explode(' ', $extraOptions),
             self::DEFAULT_ARGS_AND_OPTIONS
         ));

--- a/tests/phpunit/CodeceptionAdapterTest.php
+++ b/tests/phpunit/CodeceptionAdapterTest.php
@@ -357,6 +357,24 @@ final class CodeceptionAdapterTest extends FileSystemTestCase
         self::assertSame('codeception', $this->createAdapter()->getName());
     }
 
+    public function test_prepare_arguments_and_options_contains_run_first(): void
+    {
+        $adapter = $this->createAdapter();
+
+        $commandLine = $adapter->getMutantCommandLine(
+            [],
+            self::MUTATED_FILE_PATH,
+            self::MUTATION_HASH,
+            self::ORIGINAL_FILE_PATH,
+            '--skip blah'
+        );
+
+        self::assertStringContainsString(
+            'path/to/codeception run --skip blah',
+            implode(' ', $commandLine)
+        );
+    }
+
     /**
      * @param array<string, mixed>|null $config
      */


### PR DESCRIPTION
When putting in `--test-framework-options`, it is putting the options before the `run` command. The fix is to make sure the options are place after the `run` command.

Before changes: Running `infection --test-framework-options="--skip blah"` runs the command `codecept --skip blah run`

After changes: Running `infection --test-framework-options="--skip blah"` runs the command
`codecept run --skip blah`