### PR TITLE
ci: Configure the concurrency for the GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,10 @@ on:
       - main
       - master
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+    cancel-in-progress: true
+
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/cs.yaml
+++ b/.github/workflows/cs.yaml
@@ -10,6 +10,10 @@ on:
       - main
       - master
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+    cancel-in-progress: true
+
 jobs:
   coding-standards:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -10,6 +10,10 @@ on:
       - main
       - master
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+    cancel-in-progress: true
+
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/mt.yaml
+++ b/.github/workflows/mt.yaml
@@ -10,6 +10,10 @@ on:
       - main
       - master
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+    cancel-in-progress: true
+
 jobs:
   mutation-testing:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This only the latest PR or commit on the main branch gets a job, the previous ones are cancelled.