### PR TITLE
ci: Rename the jobs and workflows for better readability

### DIFF
--- a/.github/workflows/cs.yaml
+++ b/.github/workflows/cs.yaml
@@ -21,9 +21,13 @@ jobs:
       matrix:
         operating-system: [ ubuntu-latest ]
         php-version: [ '8.2' ]
-        check: [ 'cs', 'phpstan' ]
+        check:
+          - makefile-target: 'cs'
+            name: 'CS'
+          - makefile-target: 'phpstan'
+            name: 'PHPStan'
 
-    name: Coding Standards on PHP ${{ matrix.php-version }}
+    name: ${{ matrix.check.name }} on PHP ${{ matrix.php-version }}
 
     steps:
       - name: Checkout
@@ -53,8 +57,8 @@ jobs:
         run: |
           composer install --no-interaction --no-progress --prefer-dist
 
-      - name: Run ${{ matrix.check }}
-        run: make ${{ matrix.check }}
+      - name: Run ${{ matrix.check.makefile-target }}
+        run: make ${{ matrix.check.makefile-target }}
 
   # This is a meta job to avoid to have to constantly change the protection rules
   # whenever we touch the matrix.

--- a/.github/workflows/mutation-testing.yaml
+++ b/.github/workflows/mutation-testing.yaml
@@ -23,7 +23,7 @@ jobs:
         php-version: [ '8.2' ]
         coverage-driver: [ pcov ]
 
-    name: Mutation testing with PHP ${{ matrix.php-version }}, using ${{ matrix.coverage-driver }}
+    name: Mutation testing with PHP ${{ matrix.php-version }} (${{ matrix.coverage-driver }})
 
     steps:
       - name: Checkout code

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,7 +30,7 @@ jobs:
           - php-version: '8.1'
             symfony-require: '^7'
 
-    name: CI with PHP ${{ matrix.php-version }}, using ${{ matrix.coverage-driver }}, with Symfony ${{ matrix.symfony-require }}
+    name: Unit tests on PHP ${{ matrix.php-version }} with Symfony ${{ matrix.symfony-require }} (${{ matrix.coverage-driver }})
 
     steps:
       - name: Checkout
@@ -80,7 +80,7 @@ jobs:
         php-version: [ '8.2', '8.3', '8.4', '8.5' ]
         coverage-driver: [ pcov ]
 
-    name: CI with PHP ${{ matrix.php-version }}, using ${{ matrix.coverage-driver }}
+    name: End-to-end with PHP ${{ matrix.php-version }} (${{ matrix.coverage-driver }})
 
     steps:
       - name: Checkout


### PR DESCRIPTION
`ci` and `CI on` makes no sense: this is a GitHub Actions workflow or job, it is part of the CI. Instead, it is more interesting to know if it's a unit test or an end-to-end test.

Because the job label can't be too long (it gets truncated), I renamed `Unit tests with PHP 8.4 using pcov` to `Unit tests with PHP 8.4 (pcov)`.