### PR TITLE
build: Verify the PHARs signature before using them

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,17 @@ PHP=$(shell which php)
 # Default parallelism
 JOBS=$(shell nproc)
 
+TOOL_DOWNLOAD_DIR := var/download
+TOOL_DIR := var/tools
+
 # PHP CS Fixer
-PHP_CS_FIXER=./.tools/php-cs-fixer
-PHP_CS_FIXER_URL="https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v3.35.1/php-cs-fixer.phar"
+PHP_CS_FIXER := $(TOOL_DIR)/php-cs-fixer.phar
+PHP_CS_FIXER_VERSION := .tools/php-cs-fixer-version
+PHP_CS_FIXER_GPG_KEY := E82B2FB314E9906E
+TMP_PHP_CS_FIXER := $(TOOL_DOWNLOAD_DIR)/$(shell basename $(PHP_CS_FIXER))
+TMP_PHP_CS_FIXER_SIGNATURE := $(TMP_PHP_CS_FIXER).asc
+PHP_CS_FIXER_URL := "https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/$(shell cat $(PHP_CS_FIXER_VERSION))/php-cs-fixer.phar"
+PHP_CS_FIXER_URL_SIGNATURE := "https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/$(shell cat $(PHP_CS_FIXER_VERSION))/php-cs-fixer.phar.asc"
 
 # PHPUnit
 PHPUNIT=vendor/bin/phpunit
@@ -97,7 +105,26 @@ $(INFECTION): Makefile
 	chmod a+x $(INFECTION)
 	touch $@
 
-$(PHP_CS_FIXER): Makefile
-	wget -q $(PHP_CS_FIXER_URL) --output-document=$(PHP_CS_FIXER)
-	chmod a+x $(PHP_CS_FIXER)
-	touch $@
+$(PHP_CS_FIXER): $(PHP_CS_FIXER_VERSION)
+	$(MAKE) $(TMP_PHP_CS_FIXER)
+
+	mkdir -p $(TOOL_DOWNLOAD_DIR)
+	mv $(TMP_PHP_CS_FIXER) $@
+	touch -c $@
+
+$(TMP_PHP_CS_FIXER): $(PHP_CS_FIXER_VERSION)
+	mkdir -p $(TOOL_DOWNLOAD_DIR)
+	wget --quiet $(PHP_CS_FIXER_URL) --output-document=$@
+	wget --quiet $(PHP_CS_FIXER_URL_SIGNATURE) --output-document=$(TMP_PHP_CS_FIXER_SIGNATURE)
+
+	@echo "Importing GPG key..."
+	@gpg --keyserver hkps://keys.openpgp.org --recv-keys $(PHP_CS_FIXER_GPG_KEY) >/dev/null 2>&1 || \
+		(echo "ERROR: Failed to import GPG key" && rm -f $@ $(TMP_PHP_CS_FIXER_SIGNATURE) && exit 1)
+	@echo "Verifying signature..."
+	@gpg --verify $(TMP_PHP_CS_FIXER_SIGNATURE) $@ >/dev/null 2>&1 || \
+		(echo "ERROR: Signature verification FAILED!" && rm -f $@ $(TMP_PHP_CS_FIXER_SIGNATURE) && exit 1)
+	@echo "✓ Signature verification passed"
+	rm -f $(TMP_PHP_CS_FIXER_SIGNATURE)
+
+	chmod a+x $@
+	PHP_CS_FIXER_IGNORE_ENV=1 $@ --version


### PR DESCRIPTION
There is a few issues with the way we use the PHAR tools currently:

- We do not verify them before using them. Neither the signature, neither if they work at all (i.e. were correctly downloaded, or maybe the shipped PHAR is crap).
- Whenever we change the `Makefile` (regardless of whether it's the "download PHAR section", we invalidate the PHARs triggering their reload.
- It is hard to update (we need to constantly update the URL in `Makefile`)

Typically when working on the train this happened several times: either I had no connection or it wasn't stable and I couldn't use the make commands directly due to the PHARs being deleted and requiring to be downloaded again.

This PR is an attempt to fix this:

- We define the _version_ of the tool in `.tools/tool-name-version`. This is what defines which version we used, and its easier to update. I experimented with an [update workflow in the phpspec-adapter repository](https://github.com/infection/phpspec-adapter/blob/master/.github/workflows/update.yaml) to do that. It will trigger regularly (it is configured as a cron) and will do a PR if necessary triggering the checks, mimicking the experience we would have with dependabot or equivalent.
- the makefile:
  - downloads the PHP-CS-Fixer PHAR and its signature (`.asc`)
  - use `gpg` to verify the signing
  - makes it executable and tries to display the version as a smoke test
  - moves it to the desired location

I must say I'm not happy with the gpg check: it is verbose and annoying. For reference, it is now possible to use [gh attestation verify](https://cli.github.com/manual/gh_attestation_verify) which makes it only need:

```
wget ...
gh attestation verify --owner php pie.phar
```

But not all tools switched to that yet.

Anyway this was more to report on the issue and see what it takes. So to recap, we have the following:

1. Having to define the PHAR version in a separate file and use that to know if the PHAR needs to be downloaded again or not instead of the `Makefile` itself.
2. Having the download + any verification done in a separate directly, so that if it fails and you had a working PHAR, it does not get replaced.
3. Having the GPG/gh attestation verify check
4. Having the `--version` check
5. Having the update workflow to keep the PHARs up to date.
6. Having a composite GitHub Action to cache the PHAR in the CI.

Which ones you're unhappy with and think we should remove?

I at the very least feel strongly about 1) and 5). For 3) I also feel strongly if gh attestation is available, I don't like the implementation for the GPG check so I'm fine skipping it although I don't like to run untrusted PHARs. 4. is also cheap, but i don't feel overly strongly about it.

Depending on your stance on this I'll update each repo accordingly.