### PR TITLE
build: Configure the tools to use the var directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,6 @@
 /.tools/
 /build/
 /infection.log
+/tests/e2e/*/var/
+/var/
 /vendor/

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -50,6 +50,7 @@ $finder = Finder::create()
         '.github',
         'build',
         'tests/e2e',
+        'var',
     ])
     ->ignoreDotFiles(false)
     ->name('*php')
@@ -151,4 +152,5 @@ return (new Config())
         ],
     ])
     ->setFinder($finder)
+    ->setCacheFile(__DIR__ . '/var/cache/php-cs-fixer')
 ;

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -2,6 +2,7 @@ includes:
     - phpstan-baseline.neon
 
 parameters:
+    tmpDir: var/phpstan-cache
     level: max
     inferPrivatePropertyTypeFromConstructor: true
     ignoreErrors:

--- a/infection.json5
+++ b/infection.json5
@@ -1,4 +1,5 @@
 {
+    "tmpDir": "var/infection",
     "source": {
         "directories": [
             "src"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,6 +4,7 @@
          bootstrap="./vendor/autoload.php"
          colors="true"
          executionOrder="random"
+         cacheResultFile="var/phpunit-cache"
          verbose="true"
 >
     <coverage>

--- a/tests/e2e/Codeception_Basic/infection.json5
+++ b/tests/e2e/Codeception_Basic/infection.json5
@@ -1,4 +1,5 @@
 {
+    "$schema": "vendor/infection/infection/resources/schema.json",
     "timeout": 25,
     "source": {
         "directories": [
@@ -6,8 +7,8 @@
         ]
     },
     "logs": {
-        "summary": "infection.log"
+        "summary": "var/infection.log"
     },
-    "tmpDir": ".",
+    "tmpDir": "var/infection",
     "testFramework": "codeception"
 }

--- a/tests/e2e/Codeception_Basic/run_tests.bash
+++ b/tests/e2e/Codeception_Basic/run_tests.bash
@@ -27,5 +27,5 @@ composer install
 
 run "vendor/bin/infection"
 
-diff -w expected-output.txt infection.log
+diff -w expected-output.txt var/infection.log
 

--- a/tests/e2e/Codeception_With_Suite_Overridings/infection.json5
+++ b/tests/e2e/Codeception_With_Suite_Overridings/infection.json5
@@ -1,4 +1,5 @@
 {
+    "$schema": "vendor/infection/infection/resources/schema.json",
     "timeout": 25,
     "source": {
         "directories": [
@@ -6,8 +7,8 @@
         ]
     },
     "logs": {
-        "summary": "infection.log"
+      "summary": "var/infection.log"
     },
-    "tmpDir": ".",
+    "tmpDir": "var/infection",
     "testFramework": "codeception"
 }

--- a/tests/e2e/Codeception_With_Suite_Overridings/run_tests.bash
+++ b/tests/e2e/Codeception_With_Suite_Overridings/run_tests.bash
@@ -39,4 +39,4 @@ composer install
 
 run "vendor/bin/infection"
 
-diff -w expected-output.txt infection.log
+diff -w expected-output.txt var/infection.log

--- a/tests/e2e/Codeception_With_Suite_Overridings/tests/integration.suite.yml
+++ b/tests/e2e/Codeception_With_Suite_Overridings/tests/integration.suite.yml
@@ -3,7 +3,7 @@ modules:
     enabled:
         - \Codeception_With_Suite_Overridings\Helper\Integration
         - Db:
-              dsn: 'sqlite:stuff.sq3'
+              dsn: 'sqlite:var/stuff.sq3'
               user: 'test'
               password: 'test'
               dump:


### PR DESCRIPTION
Reduce the amount of clutter spread everywhere to a dedicated temporary directory.

Follow the same spirit as https://github.com/infection/infection/pull/2593.