### PR TITLE
build: Fix the composer.lock

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e373df1dfeb78c4bf5eec4acdbd86a31",
+    "content-hash": "24a42db2450ea3ec3f8118d8282d3330",
     "packages": [
         {
             "name": "infection/abstract-testframework-adapter",


### PR DESCRIPTION
Currently `composer validate --strict` fails due to the .lock being outdated.

I updated it executing:

```shell
composer update --lock
```