### PR TITLE
cs: Update PHP-CS-Fixer

### DIFF
--- a/.github/workflows/cs.yaml
+++ b/.github/workflows/cs.yaml
@@ -17,9 +17,6 @@ jobs:
   coding-standards:
     runs-on: ubuntu-latest
 
-    env:
-        PHP_CS_FIXER_IGNORE_ENV: '1'
-
     strategy:
       matrix:
         operating-system: [ ubuntu-latest ]

--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,10 @@
 /.php-cs-fixer.cache
 /.tools/
 /build/
+/composer.lock
 /infection.log
 /tests/**/_generated/
 /tests/**/_output/
 /tests/e2e/*/var/
 /var/
 /vendor/
-/composer.lock

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This code is licensed under the BSD 3-Clause License.
  *
@@ -31,8 +32,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-declare(strict_types=1);
-
 use PhpCsFixer\Config;
 use PhpCsFixer\Finder;
 
@@ -59,10 +58,6 @@ $finder = Finder::create()
 return (new Config())
     ->setRiskyAllowed(true)
     ->setRules([
-        '@PHP71Migration' => true,
-        '@PHP71Migration:risky' => true,
-        '@PHPUnit60Migration:risky' => true,
-        '@PHPUnit75Migration:risky' => true,
         '@Symfony' => true,
         '@Symfony:risky' => true,
         'blank_line_before_statement' => [

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ help:
 
 # PHP CS Fixer
 PHP_CS_FIXER=./.tools/php-cs-fixer
-PHP_CS_FIXER_URL="https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v3.35.1/php-cs-fixer.phar"
+PHP_CS_FIXER_URL="https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v3.95.1/php-cs-fixer.phar"
 
 # PHPUnit
 PHPUNIT=vendor/bin/phpunit

--- a/src/CodeceptionAdapter.php
+++ b/src/CodeceptionAdapter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This code is licensed under the BSD 3-Clause License.
  *
@@ -30,8 +31,6 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
-declare(strict_types=1);
 
 namespace Infection\TestFramework\Codeception;
 

--- a/src/CodeceptionAdapterFactory.php
+++ b/src/CodeceptionAdapterFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This code is licensed under the BSD 3-Clause License.
  *
@@ -30,8 +31,6 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
-declare(strict_types=1);
 
 namespace Infection\TestFramework\Codeception;
 

--- a/src/CodeceptionConfigParseException.php
+++ b/src/CodeceptionConfigParseException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This code is licensed under the BSD 3-Clause License.
  *
@@ -30,8 +31,6 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
-declare(strict_types=1);
 
 namespace Infection\TestFramework\Codeception;
 

--- a/src/CommandLineBuilder.php
+++ b/src/CommandLineBuilder.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This code is licensed under the BSD 3-Clause License.
  *
@@ -30,8 +31,6 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
-declare(strict_types=1);
 
 namespace Infection\TestFramework\Codeception;
 

--- a/src/Coverage/JUnitTestCaseSorter.php
+++ b/src/Coverage/JUnitTestCaseSorter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This code is licensed under the BSD 3-Clause License.
  *
@@ -30,8 +31,6 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
-declare(strict_types=1);
 
 namespace Infection\TestFramework\Codeception\Coverage;
 

--- a/src/Stringifier.php
+++ b/src/Stringifier.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This code is licensed under the BSD 3-Clause License.
  *
@@ -30,8 +31,6 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
-declare(strict_types=1);
 
 namespace Infection\TestFramework\Codeception;
 

--- a/src/VersionParser.php
+++ b/src/VersionParser.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This code is licensed under the BSD 3-Clause License.
  *
@@ -30,8 +31,6 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
-declare(strict_types=1);
 
 namespace Infection\TestFramework\Codeception;
 

--- a/tests/phpunit/Adapter/CodeceptionAdapterFactoryTest.php
+++ b/tests/phpunit/Adapter/CodeceptionAdapterFactoryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This code is licensed under the BSD 3-Clause License.
  *
@@ -30,8 +31,6 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
-declare(strict_types=1);
 
 namespace Infection\Tests\TestFramework\Codeception\Adapter;
 

--- a/tests/phpunit/Adapter/CodeceptionAdapterTest.php
+++ b/tests/phpunit/Adapter/CodeceptionAdapterTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This code is licensed under the BSD 3-Clause License.
  *
@@ -30,8 +31,6 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
-declare(strict_types=1);
 
 namespace Infection\Tests\TestFramework\Codeception\Adapter;
 

--- a/tests/phpunit/Adapter/CodeceptionConfigParseExceptionTest.php
+++ b/tests/phpunit/Adapter/CodeceptionConfigParseExceptionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This code is licensed under the BSD 3-Clause License.
  *
@@ -30,8 +31,6 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
-declare(strict_types=1);
 
 namespace Infection\Tests\TestFramework\Codeception\Adapter;
 

--- a/tests/phpunit/Adapter/Coverage/JUnitTestCaseSorterTest.php
+++ b/tests/phpunit/Adapter/Coverage/JUnitTestCaseSorterTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This code is licensed under the BSD 3-Clause License.
  *
@@ -30,8 +31,6 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
-declare(strict_types=1);
 
 namespace Infection\Tests\TestFramework\Codeception\Adapter\Coverage;
 

--- a/tests/phpunit/Adapter/StringifierTest.php
+++ b/tests/phpunit/Adapter/StringifierTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This code is licensed under the BSD 3-Clause License.
  *
@@ -30,8 +31,6 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
-declare(strict_types=1);
 
 namespace Infection\Tests\TestFramework\Codeception\Adapter;
 

--- a/tests/phpunit/Adapter/VersionParserTest.php
+++ b/tests/phpunit/Adapter/VersionParserTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This code is licensed under the BSD 3-Clause License.
  *
@@ -30,8 +31,6 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
-declare(strict_types=1);
 
 namespace Infection\Tests\TestFramework\Codeception\Adapter;
 

--- a/tests/phpunit/FileSystem/FileSystemTestCase.php
+++ b/tests/phpunit/FileSystem/FileSystemTestCase.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This code is licensed under the BSD 3-Clause License.
  *
@@ -30,8 +31,6 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
-declare(strict_types=1);
 
 /*
  * This file is part of the box project.

--- a/tests/phpunit/Helpers.php
+++ b/tests/phpunit/Helpers.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This code is licensed under the BSD 3-Clause License.
  *
@@ -30,8 +31,6 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
-declare(strict_types=1);
 
 namespace Infection\Tests\TestFramework\Codeception;
 


### PR DESCRIPTION
This PR:

- Update PHP-CS-Fixer from `v3.35.1` to `v3.95.1`.
- Drop the usage of the environment variable `PHP_CS_FIXER_IGNORE_ENV` (no longer needed).
- Drop the legacy rules:
    - `@PHP71Migration`
    - `@PHP71Migration:risky`
    - `@PHPUnit60Migration:risky`
    - `@PHPUnit75Migration:risky`
- Apply PHP-CS-Fixer 