### PR TITLE
build: Remove unused arguments for PHPUnit

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -71,7 +71,7 @@ jobs:
       - name: Upload coverage results to Coveralls
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: vendor/bin/php-coveralls
+        run: vendor/bin/php-coveralls --coverage_clover=var/phpunit-clover.xml
 
   e2e:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ PHP_CS_FIXER_URL="https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download
 
 # PHPUnit
 PHPUNIT=vendor/bin/phpunit
+PHPUNIT_COVERAGE_CLOVER=--coverage-clover=build/logs/clover.xml
+PHPUNIT_ARGS=--coverage-xml=build/logs/coverage-xml --log-junit=build/logs/junit.xml $(PHPUNIT_COVERAGE_CLOVER)
 
 # PHPStan
 PHPSTAN=vendor/bin/phpstan
@@ -67,7 +69,7 @@ phpstan:
 
 .PHONY: test-unit
 test-unit: vendor/autoload.php
-	$(PHPUNIT)
+	$(PHPUNIT) $(PHPUNIT_ARGS)
 
 .PHONY: test-e2e
 test-e2e: vendor/autoload.php

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,6 @@ PHP_CS_FIXER_URL="https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download
 
 # PHPUnit
 PHPUNIT=vendor/bin/phpunit
-PHPUNIT_COVERAGE_CLOVER=--coverage-clover=build/logs/clover.xml
-PHPUNIT_ARGS=--coverage-xml=build/logs/coverage-xml --log-junit=build/logs/junit.xml $(PHPUNIT_COVERAGE_CLOVER)
 
 # PHPStan
 PHPSTAN=vendor/bin/phpstan
@@ -69,7 +67,7 @@ phpstan:
 
 .PHONY: test-unit
 test-unit: vendor/autoload.php
-	$(PHPUNIT) $(PHPUNIT_ARGS)
+	$(PHPUNIT)
 
 .PHONY: test-e2e
 test-e2e: vendor/autoload.php

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,7 @@ PHP_CS_FIXER_URL="https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download
 
 # PHPUnit
 PHPUNIT=vendor/bin/phpunit
-PHPUNIT_COVERAGE_CLOVER=--coverage-clover=build/logs/clover.xml
-PHPUNIT_ARGS=--coverage-xml=build/logs/coverage-xml --log-junit=build/logs/junit.xml $(PHPUNIT_COVERAGE_CLOVER)
+PHPUNIT_ARGS=--coverage-clover=var/phpunit-clover.xml
 
 # PHPStan
 PHPSTAN=vendor/bin/phpstan


### PR DESCRIPTION
Currently executing PHPUnit will generate clover, JUnit and XML coverage reports in `build/logs`, which is should be changed for `var` (see #45).

However, I noticed that none of those reports are actually used, ~~neither in the CI~~, neither by infection (it executes the tests itself).

Edit: It appears we were relying on the default path for the clover report to update it to Coveralls. I adjusted the path to `var` and set the path explicitly.